### PR TITLE
Fix example code and add a command to show a translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/yaml": "7.0.*",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0",
-        "webfactory/polyglot-bundle": "dev-master"
+        "webfactory/polyglot-bundle": "^4.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba89a259be60a9b130b26bed8ccaf0d8",
+    "content-hash": "571033da11c1e6731870ba6fb3e56f3a",
     "packages": [
         {
             "name": "composer/semver",
@@ -268,16 +268,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.8.3",
+            "version": "3.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "db922ba9436b7b18a23d1653a0b41ff2369ca41c"
+                "reference": "b05e48a745f722801f55408d0dbd8003b403dbbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/db922ba9436b7b18a23d1653a0b41ff2369ca41c",
-                "reference": "db922ba9436b7b18a23d1653a0b41ff2369ca41c",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/b05e48a745f722801f55408d0dbd8003b403dbbd",
+                "reference": "b05e48a745f722801f55408d0dbd8003b403dbbd",
                 "shasum": ""
             },
             "require": {
@@ -361,7 +361,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.8.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.8.4"
             },
             "funding": [
                 {
@@ -377,7 +377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-03T15:55:06+00:00"
+            "time": "2024-04-25T07:04:44+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -6150,16 +6150,16 @@
         },
         {
             "name": "symfony/stimulus-bundle",
-            "version": "v2.16.0",
+            "version": "v2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stimulus-bundle.git",
-                "reference": "6add4bdab1b9df4f2b2532a9dcb7b2f26dbba634"
+                "reference": "b828a32fe9f75500d26b563cc01874657162c413"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stimulus-bundle/zipball/6add4bdab1b9df4f2b2532a9dcb7b2f26dbba634",
-                "reference": "6add4bdab1b9df4f2b2532a9dcb7b2f26dbba634",
+                "url": "https://api.github.com/repos/symfony/stimulus-bundle/zipball/b828a32fe9f75500d26b563cc01874657162c413",
+                "reference": "b828a32fe9f75500d26b563cc01874657162c413",
                 "shasum": ""
             },
             "require": {
@@ -6169,7 +6169,7 @@
                 "symfony/deprecation-contracts": "^2.0|^3.0",
                 "symfony/finder": "^5.4|^6.0|^7.0",
                 "symfony/http-kernel": "^5.4|^6.0|^7.0",
-                "twig/twig": "^2.15.3|~3.8.0"
+                "twig/twig": "^2.15.3|^3.8"
             },
             "require-dev": {
                 "symfony/asset-mapper": "^6.3|^7.0",
@@ -6199,7 +6199,7 @@
                 "symfony-ux"
             ],
             "support": {
-                "source": "https://github.com/symfony/stimulus-bundle/tree/v2.16.0"
+                "source": "https://github.com/symfony/stimulus-bundle/tree/v2.17.0"
             },
             "funding": [
                 {
@@ -6215,7 +6215,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-29T16:20:46+00:00"
+            "time": "2024-04-21T10:23:35+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -6731,16 +6731,16 @@
         },
         {
             "name": "symfony/ux-turbo",
-            "version": "v2.16.0",
+            "version": "v2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-turbo.git",
-                "reference": "d3590a43fee73304855dfc8022ccb57b0df9f03d"
+                "reference": "7093e20d7ca599902a7d1bf4d831849fd78befdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-turbo/zipball/d3590a43fee73304855dfc8022ccb57b0df9f03d",
-                "reference": "d3590a43fee73304855dfc8022ccb57b0df9f03d",
+                "url": "https://api.github.com/repos/symfony/ux-turbo/zipball/7093e20d7ca599902a7d1bf4d831849fd78befdb",
+                "reference": "7093e20d7ca599902a7d1bf4d831849fd78befdb",
                 "shasum": ""
             },
             "require": {
@@ -6807,7 +6807,7 @@
                 "turbo-stream"
             ],
             "support": {
-                "source": "https://github.com/symfony/ux-turbo/tree/v2.16.0"
+                "source": "https://github.com/symfony/ux-turbo/tree/v2.17.0"
             },
             "funding": [
                 {
@@ -6823,7 +6823,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-20T16:11:17+00:00"
+            "time": "2024-04-22T13:58:54+00:00"
         },
         {
             "name": "symfony/validator",
@@ -7308,30 +7308,37 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.8.0",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
+                "reference": "a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58",
+                "reference": "a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3",
                 "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -7364,7 +7371,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.9.3"
             },
             "funding": [
                 {
@@ -7376,20 +7383,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-21T18:54:41+00:00"
+            "time": "2024-04-18T11:59:33+00:00"
         },
         {
             "name": "webfactory/polyglot-bundle",
-            "version": "dev-master",
+            "version": "4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webfactory/WebfactoryPolyglotBundle.git",
-                "reference": "642c759e929b26f39057662914011ad7d34ba30b"
+                "reference": "ccca471ff1e1342c90610ca6cf2b6f35bc2049e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webfactory/WebfactoryPolyglotBundle/zipball/642c759e929b26f39057662914011ad7d34ba30b",
-                "reference": "642c759e929b26f39057662914011ad7d34ba30b",
+                "url": "https://api.github.com/repos/webfactory/WebfactoryPolyglotBundle/zipball/ccca471ff1e1342c90610ca6cf2b6f35bc2049e2",
+                "reference": "ccca471ff1e1342c90610ca6cf2b6f35bc2049e2",
                 "shasum": ""
             },
             "require": {
@@ -7416,7 +7423,6 @@
                 "symfony/yaml": "^5.4|^6.4|^7.0",
                 "webfactory/doctrine-orm-test-infrastructure": "^1.14"
             },
-            "default-branch": true,
             "type": "symfony-bundle",
             "autoload": {
                 "psr-4": {
@@ -7438,9 +7444,9 @@
             "description": "Symfony Bundle simplifying translations of values stored in Doctrine ORM entities",
             "support": {
                 "issues": "https://github.com/webfactory/WebfactoryPolyglotBundle/issues",
-                "source": "https://github.com/webfactory/WebfactoryPolyglotBundle/tree/master"
+                "source": "https://github.com/webfactory/WebfactoryPolyglotBundle/tree/4.1.2"
             },
-            "time": "2024-04-19T13:42:36+00:00"
+            "time": "2024-04-26T10:03:06+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -9941,9 +9947,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "webfactory/polyglot-bundle": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/Command/ShowTranslationCommand.php
+++ b/src/Command/ShowTranslationCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Document;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('show-translations')]
+class ShowTranslationCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('document-id', InputArgument::REQUIRED);
+        $this->addArgument('locale', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $docuentId = $input->getArgument('document-id');
+        $document = $this->entityManager->find(Document::class, $docuentId);
+
+        if (!$document) {
+            $output->writeln('<error>Document not found</error>');
+
+            return Command::FAILURE;
+        }
+
+        $locale = $input->getArgument('locale');
+
+        $output->writeln($document->getText()->translate($locale));
+
+        $this->entityManager->clear();
+        $this->entityManager->find(Document::class, $docuentId);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -10,11 +10,8 @@ class AppFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-        // $product = new Product();
-        // $manager->persist($product);
-
-        $document = (new Document())
-            ;
+        $document = new Document('Hello translations 🇬🇧');
+        $document->getText()->setTranslation('Hallo Übersetzungen 🇩🇪', 'de_DE');
         $manager->persist($document);
 
         $manager->flush();

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
 #[Polyglot\Locale(primary: "en_GB")]
@@ -34,14 +35,14 @@ class Document
     #[ORM\Column(type: 'translatable_string')]
     private TranslatableInterface $text;
 
-    public function __construct()
+    public function __construct(string $text)
     {
-        // ...
+        $this->text = new Translatable($text, 'en_GB');
         $this->translations = new ArrayCollection();
     }
 
-    public function getText(): string
+    public function getText(): TranslatableInterface
     {
-        return $this->text->translate();
+        return $this->text;
     }
 }


### PR DESCRIPTION
This fixes the example code and adds a command to show the imported translations.

Run the fixtures import command as shown in the README, and then:

```
$ bin/console show-translations 1 en_GB
Hello translations 🇬🇧
$ bin/console show-translations 1 de_DE
Hallo Übersetzungen 🇩🇪
```


